### PR TITLE
Fix `low_mass_torques` to work with MESA r21.12.1-rc1

### DIFF
--- a/hooks/low_mass_torques/low_mass_torques.inc
+++ b/hooks/low_mass_torques/low_mass_torques.inc
@@ -51,22 +51,22 @@
                ! Figure out how massive the top convection zone is
                net_I = 0d0
                do k=1,k_end   
-                  net_I = net_I + s% i_rot(k) * s% dm(k) 
+                  net_I = net_I + s% i_rot(k)%val * s% dm(k)
                end do
 
                ! Distribute Jdot
                do k=1,k_end
-                  s% extra_jdot(k) = -jdot * s% i_rot(k) * s% dm(k)  / net_I
+                  s% extra_jdot(k) = -jdot * s% i_rot(k)%val * s% dm(k)  / net_I
                end do
             else if (wind_distribution_option == 2) then
                ! Distribute jdot proportional to i_rot in the whole star
                net_I = 0d0
                do k=1,s% nz
-                  net_I = net_I + s% i_rot(k) * s% dm(k) 
+                  net_I = net_I + s% i_rot(k)%val * s% dm(k)
                end do
 
                do k=1,s% nz   
-                  s% extra_jdot(k) = -jdot * s% i_rot(k) * s% dm(k) / net_I
+                  s% extra_jdot(k) = -jdot * s% i_rot(k)%val * s% dm(k) / net_I
                end do
             end if
    

--- a/hooks/low_mass_torques/star_example/inlist_project
+++ b/hooks/low_mass_torques/star_example/inlist_project
@@ -66,7 +66,7 @@
 
     mixing_length_alpha = 1.816711
     ! options for energy conservation (see MESA V, Section 3)
-    use_dedt_form_of_energy_eqn = .true.
+    energy_eqn_option = 'dedt'
     use_gold_tolerances = .true.
 
     max_age = 2d9


### PR DESCRIPTION
The change of `s% i_rot` from a `real(dp)` to an `auto_diff` type broke `low_mass_torques`. This small PR fixes `low_mass_torques` by using `s% i_rot(k)%val` instead of `s% i_rot(k)`, which I'm pretty sure is the right thing to do but I wanted to give @adamjermyn a chance to check that I haven't broken something.